### PR TITLE
Don't require clojure.core/Inst to stop redefine warning

### DIFF
--- a/src/mudguard/core.clj
+++ b/src/mudguard/core.clj
@@ -1,6 +1,7 @@
 (ns mudguard.core
   (:require [clojure.string :as str])
-  (:import (clojure.lang APersistentVector APersistentMap)))
+  (:import (clojure.lang APersistentVector APersistentMap))
+  (:refer-clojure :exclude [Inst]))
 
 ;; Result values
 (defn validation-error


### PR DESCRIPTION
Stops ` WARNING: Inst already refers to: #'clojure.core/Inst in namespace: mudguard.core, being replaced by: #'mudguard.core/Inst` when namespace is loaded